### PR TITLE
Enable Static Export & Auto-Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js and PNPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+          pnpm install --frozen-lockfile
+
+      - name: Build and export
+        run: pnpm run deploy
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          publish_branch: gh-pages

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // enable static export for GitHub Pages
+  output: 'export',
+  // ensure folder-per-page output (index.html files)
+  trailingSlash: true,
+  // repo path, e.g. https://fablabbcn.github.io/more4nature-website
+  basePath: '/more4nature-website',
   async redirects() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev --turbo",
     "build": "next build",
-    "start": "next start",
+    "export": "next export",
+    "deploy": "npm run build && npm run export",
     "test": "jest --config jest.config.ts",
     "lint": "next lint"
   },


### PR DESCRIPTION
**PR Description**
This change adds support for exporting our Next.js site as a fully static build and automates deployment to GitHub Pages whenever we push to `main`.

**What’s been updated**

1. **`next.config.js`**

   * Switched `output` from `standalone` to `export`
   * Added `trailingSlash: true` for proper folder structure
   * Introduced `basePath` for project-page hosting

2. **`package.json`**

   * Removed the `start` script (no server needed)
   * Added `"export": "next export"` and `"deploy": "npm run build && npm run export"`

3. **New GitHub Actions workflow** (`.github/workflows/deploy.yml`)

   * Triggers on pushes to `main`
   * Installs dependencies with PNPM via Corepack
   * Runs `pnpm run deploy` to generate static files in `/out`
   * Uses `peaceiris/actions-gh-pages` to publish `/out` to the `gh-pages` branch

After merging, pushes to `main` will automatically rebuild and publish the site at `https://fablabbcn.github.io/more4nature-eu`.
